### PR TITLE
fix: define typeahead config constants

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,6 +48,18 @@ const STATUS_TRADE = "trade";
 const THEME_STORAGE_KEY = "rom_theme";
 const THEME_LIGHT = "light";
 const THEME_DARK = "dark";
+const TYPEAHEAD_MIN_CHARS = 2;
+const TYPEAHEAD_DEBOUNCE_MS = 180;
+const TYPEAHEAD_LIMIT = 8;
+const TYPEAHEAD_SELECT_COLUMNS = [
+  COL_GAME,
+  COL_PLATFORM,
+  COL_GENRE,
+  COL_RELEASE_YEAR,
+]
+  .map((column) => column.trim())
+  .filter(Boolean)
+  .join(",");
 
 const STATUS_OPTIONS = [
   { value: STATUS_NONE, label: "None" },


### PR DESCRIPTION
## Summary
- add explicit configuration constants for the search typeahead module
- ensure Supabase queries receive a consistent column selection string
- unblock the lint workflow by eliminating previously undefined identifiers

## Plan
1. Review the typeahead implementation for missing constant definitions.
2. Introduce shared constants for the feature near other configuration values.
3. Run eslint to confirm the undefined identifiers warning is resolved.

## Changes
- app.js

## Verification
Commands:
```
npm run lint
```
Evidence:
- lint output attached in logs

## Risks & Mitigations
- Misconfigured thresholds could impact UX → Picked conservative defaults used across project.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c13e05a883239a7464548991b6d8)