### PR TITLE
fix: remove unused remote filter tracking

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,8 +412,6 @@ const streamState = {
   filterPayload: null,
   filterSignature: null,
 };
-let remoteFilterSignature = null;
-let remoteRefreshPromise = null;
 const statusRowCache = new Map();
 let pendingStatusHydration = null;
 let latestFilteredData = [];
@@ -2157,7 +2155,7 @@ function refreshFilteredView(reason = "unknown") {
       signature !== streamState.filterSignature &&
       !reason.startsWith("stream:")
     ) {
-      requestRemoteFilterRefresh(payload, signature, reason);
+      requestRemoteFilterRefresh(payload, signature);
       return [];
     }
     if (!streamState.filterSignature) {
@@ -2202,9 +2200,8 @@ function finalizeFilteredRender(reason = "unknown") {
   return filtered;
 }
 
-function requestRemoteFilterRefresh(payload, signature, triggerReason) {
+function requestRemoteFilterRefresh(payload, signature) {
   if (!shouldUseServerFiltering()) return;
-  remoteFilterSignature = signature;
   streamState.filterPayload = { ...payload };
   streamState.filterSignature = signature;
   streamState.nextFrom = 0;
@@ -2219,7 +2216,7 @@ function requestRemoteFilterRefresh(payload, signature, triggerReason) {
   streamState.loading = true;
   updateBrowseSummaryLoading(true);
   const activeSignature = signature;
-  remoteRefreshPromise = fetchGamesPage(0, streamState.pageSize - 1, payload)
+  fetchGamesPage(0, streamState.pageSize - 1, payload)
     .then((page) => {
       if (streamState.filterSignature !== activeSignature) return;
       const rows = Array.isArray(page.data) ? page.data : [];
@@ -2237,7 +2234,6 @@ function requestRemoteFilterRefresh(payload, signature, triggerReason) {
         streamState.loading = false;
         updateBrowseSummaryLoading(false);
       }
-      remoteRefreshPromise = null;
     });
 }
 


### PR DESCRIPTION
## Summary
- remove unused remote filter tracking variables from the Supabase streaming flow
- tighten the remote refresh helper signature now that the trigger reason is unnecessary
- rerun eslint to confirm the lint task succeeds without unused variable errors

## Plan
1. Inspect the eslint failure output to identify the unused bindings.
2. Review the remote filtering workflow in `app.js` to see whether the variables are needed.
3. Remove the unused state variables and adjust the helper signature accordingly.
4. Update the caller to pass only the required arguments.
5. Run `npm run lint` to ensure the task now passes.

## Changes
- app.js

## Verification
Commands:
```
npm run lint
```
Evidence:
- `npm run lint`

## Risks & Mitigations
- None noted → minimal functional impact beyond satisfying lint.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e4eed3588323b0cd0087fa6a7c99)