### PR TITLE
fix: close valuation dashboard wrappers

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,8 @@
           </div>
           <div class="valuation-trend" aria-label="Collection value trend">
             <canvas id="valuationSparkline" width="320" height="100"></canvas>
+          </div>
+        </div>
         <div
           class="dashboard-card dashboard-price"
           id="dashboard-price"


### PR DESCRIPTION
## Summary
- add the missing closing wrappers for the valuation trend block
- ensure the dashboard section markup validates so prettier can parse it
- verify the prettier formatting check now succeeds

## Plan
1. Inspect the dashboard markup to locate the mismatched tags.
2. Close the valuation trend and card containers appropriately.
3. Run `npm run format:check` to confirm the syntax error is resolved.

## Changes
- index.html

## Verification
Commands:
```
npm run format:check
```
Evidence:
- Formatting check output attached in logs above.

## Risks & Mitigations
- Regression in dashboard layout → Verified structure locally; change only adds missing closing tags.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691256c4337883239beaa6979bc80295)