### PR TITLE
fix: show absolute update date in price summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -3235,6 +3235,22 @@ function timeAgo(timestamp) {
   return `${Math.max(1, Math.round(diff / 86400000))}d`;
 }
 
+function formatAbsoluteDate(value) {
+  if (!value) return "";
+  const date =
+    value instanceof Date
+      ? value
+      : typeof value === "number"
+        ? new Date(value)
+        : new Date(String(value));
+  if (!Number.isFinite(date.getTime())) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
 /**
  * Produce a relative time label from a date-like input.
  * @param {string|number|Date|null|undefined} value
@@ -3288,9 +3304,17 @@ function updateCollectionValueSummary() {
   });
   const updatedEl = container.querySelector("[data-price-summary-updated]");
   if (updatedEl) {
-    updatedEl.textContent = priceState.lastUpdated
-      ? `Updated ${formatRelativeDate(priceState.lastUpdated)}`
-      : "";
+    const absoluteLabel = formatAbsoluteDate(priceState.lastUpdated);
+    const relativeLabel = formatRelativeDate(priceState.lastUpdated);
+    if (absoluteLabel && relativeLabel) {
+      updatedEl.textContent = `Updated ${absoluteLabel} (${relativeLabel})`;
+    } else if (absoluteLabel) {
+      updatedEl.textContent = `Updated ${absoluteLabel}`;
+    } else if (relativeLabel) {
+      updatedEl.textContent = `Updated ${relativeLabel}`;
+    } else {
+      updatedEl.textContent = "";
+    }
   }
   container.dataset.loaded = "true";
   priceState.summaryDirty = false;


### PR DESCRIPTION
## Summary
- add an absolute date formatter for price summary updates
- show both absolute and relative timestamps in the dashboard price summary label
- ensure tests expecting the calendar year continue to pass

## Plan
1. Reproduce the failing unit test to confirm the issue.
2. Review the price summary rendering logic in `app.js`.
3. Introduce an absolute date formatter alongside the existing relative helper.
4. Update the summary label to include the absolute date (and relative fallback).
5. Re-run the unit test suite to verify the fix.

## Changes
- `app.js`

## Verification
Commands:
```
npm test
```
Evidence:
- Vitest run output (see logs above)

## Risks & Mitigations
- Locale-specific month/day formatting → Rely on `Intl.DateTimeFormat` to produce localized yet year-inclusive output.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125a44f920832385c0a71d71c9cd41)