### PR TITLE
fix: quote auth uid function body

### DIFF
--- a/supabase/migrations/20250107120000_init.sql
+++ b/supabase/migrations/20250107120000_init.sql
@@ -24,9 +24,9 @@ begin
       returns uuid
       language sql
       stable
-      as $$
+      as $func$
         select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
-      $$;
+      $func$;
     $$;
   end if;
 end;


### PR DESCRIPTION
## Summary
- ensure the auth.uid helper function in the migration uses distinct dollar-quoting
- prevent syntax errors when running the migration script via psql
- unblock `set -euo pipefail` guarded scripts from aborting on migration failure

## Plan
1. Inspect failing migration block around the auth.uid function creation.
2. Identify the nested dollar-quoting collision causing the syntax error.
3. Replace the inner dollar-quote with a unique tag to avoid premature termination.
4. Verify the migration SQL now parses without conflicting delimiters.
5. Commit the fix and prepare PR documentation.

## Changes
- supabase/migrations/20250107120000_init.sql

## Verification
Commands:
```
# not run (SQL parsing validated by inspection)
```
Evidence:
- n/a

## Risks & Mitigations
- Potential mismatch with existing auth.uid definition → Uses identical body to Supabase default, so behavior remains unchanged.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125cef4ad483239bad2f277c28db08)