### PR TITLE
fix: avoid nested dollar quotes in auth.uid migration

### DIFF
--- a/supabase/migrations/20250107120000_init.sql
+++ b/supabase/migrations/20250107120000_init.sql
@@ -9,7 +9,7 @@ create extension if not exists "pgcrypto"; -- for gen_random_uuid
 -- Ensure the auth schema/function exist so policies referencing auth.uid() succeed
 create schema if not exists auth;
 
-do $$
+do $do$
 begin
   if not exists (
     select 1
@@ -19,7 +19,7 @@ begin
       and n.nspname = 'auth'
       and pg_get_function_identity_arguments(p.oid) = ''
   ) then
-    execute $$
+    execute $exec$
       create function auth.uid()
       returns uuid
       language sql
@@ -27,10 +27,10 @@ begin
       as $func$
         select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
       $func$;
-    $$;
+    $exec$;
   end if;
 end;
-$$;
+$do$;
 
 create table if not exists public.platforms (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- adjust the migration guard for auth.uid to use distinct dollar-quote tags
- prevent the DO block from terminating early so CREATE FUNCTION executes correctly

## Plan
1. Update the DO block to avoid conflicting dollar-quote delimiters.
2. Ensure the dynamic CREATE FUNCTION statement remains idempotent.

## Changes
- supabase/migrations/20250107120000_init.sql

## Verification
Commands:
```
# not run (SQL parsing fix only)
```
Evidence:
- n/a

## Risks & Mitigations
- SQL migration regression → limited to dollar-quote delimiters; existing guard keeps idempotency.

## Follow-ups
- none


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125fbb74cc8323a1ebd6b5d43e27a4)