### PR TITLE
fix: guard dashboard aggregates grants

### DIFF
--- a/supabase/migrations/20250301100000_dashboard_aggregates.sql
+++ b/supabase/migrations/20250301100000_dashboard_aggregates.sql
@@ -3,6 +3,19 @@
 
 begin;
 
+-- Ensure grant targets exist in non-Supabase local environments
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'anon') then
+    execute 'create role anon noinherit nologin';
+  end if;
+
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then
+    execute 'create role authenticated noinherit nologin';
+  end if;
+end;
+$$;
+
 create or replace function public.rpc_genre_counts(
   _search text default null,
   _platform text default null,


### PR DESCRIPTION
## Summary
- prevent Supabase dashboard aggregates migration from failing when anon/authenticated roles are missing
- add a safety DO block that creates placeholder anon and authenticated roles in local CI databases before granting execute privileges

## Plan
1. Reproduce the migration failure referencing missing anon role.
2. Inspect the dashboard aggregates migration grants.
3. Add a guard DO block to create anon/authenticated roles when absent.
4. Re-run migration locally to ensure grants succeed (simulated).
5. Prepare documentation and PR summary.

## Changes
- supabase/migrations/20250301100000_dashboard_aggregates.sql

## Verification
Commands:
```
# Not run (local Postgres/Supabase service unavailable in CI container)
```
Evidence:
- N/A

## Risks & Mitigations
- Creating placeholder roles locally could drift from Supabase defaults → Use noinherit/nologin roles to minimize privilege impact.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691262b4b4808323973049edefe0ab02)