### PR TITLE
Fix quoting in price snapshot policy migration

### DIFF
--- a/supabase/migrations/20250315140000_pricecharting.sql
+++ b/supabase/migrations/20250315140000_pricecharting.sql
@@ -66,8 +66,12 @@ begin
       and tablename = 'game_price_snapshots'
       and policyname = 'service snapshot inserts'
   ) then
-    execute $$create policy "service snapshot inserts" on public.game_price_snapshots
-      for insert with check (coalesce(current_setting('request.jwt.claim.role', true), '') = 'service_role')$$;
+    execute format(
+      'create policy "service snapshot inserts" on public.game_price_snapshots for insert with check (coalesce(current_setting(%L, true), %L) = %L)',
+      'request.jwt.claim.role',
+      '',
+      'service_role'
+    );
   end if;
 
   if not exists (
@@ -77,8 +81,12 @@ begin
       and tablename = 'game_price_snapshots'
       and policyname = 'service snapshot deletes'
   ) then
-    execute $$create policy "service snapshot deletes" on public.game_price_snapshots
-      for delete using (coalesce(current_setting('request.jwt.claim.role', true), '') = 'service_role')$$;
+    execute format(
+      'create policy "service snapshot deletes" on public.game_price_snapshots for delete using (coalesce(current_setting(%L, true), %L) = %L)',
+      'request.jwt.claim.role',
+      '',
+      'service_role'
+    );
   end if;
 end;
 $$;


### PR DESCRIPTION
## Summary
- switch the price snapshot migration to build policy statements with format() instead of nested dollar quoting
- ensure the service-role policies can be created without syntax errors during migration execution
- leave existing read policy creation behavior untouched

## Plan
1. Reproduce the migration failure and inspect the problematic execute statements.
2. Replace the nested dollar-quoted strings with format() calls that safely quote literals.
3. Verify the migration file is the only modified asset.

## Changes
- supabase/migrations/20250315140000_pricecharting.sql

## Verification
Commands:
```
# not run (SQL migration change only)
```
Evidence:
- n/a (SQL change only)

## Risks & Mitigations
- Potential quoting mistakes in format() arguments → Verified literals and parentheses balance while editing.

## Follow-ups
- none


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912692f6a108323b5dbe5894b82028d)