### PR TITLE
fix: ensure service role exists before granting price snapshot privileges

### DIFF
--- a/supabase/migrations/20250315140000_pricecharting.sql
+++ b/supabase/migrations/20250315140000_pricecharting.sql
@@ -91,6 +91,16 @@ begin
 end;
 $$;
 
+do $$
+begin
+  if not exists (
+    select 1 from pg_roles where rolname = 'service_role'
+  ) then
+    execute 'create role service_role';
+  end if;
+end;
+$$;
+
 grant select on table public.game_price_snapshots to anon, authenticated;
 grant select on public.game_price_latest to anon, authenticated;
 


### PR DESCRIPTION
## Summary
- prevent the price snapshot migration from failing when the service_role is missing locally
- add a guard block that creates the role before privileges are granted

## Plan
1. Review the failing migration logs to confirm the missing role error.
2. Inspect the price snapshot migration for role grants.
3. Insert a guard block that creates service_role when absent.
4. Ensure grants for anon/authenticated and service_role remain intact.
5. Validate the SQL for syntax correctness.

## Changes
- supabase/migrations/20250315140000_pricecharting.sql

## Verification
Commands:
```
# not run (SQL-only change)
```
Evidence:
- Not applicable (logic change in migration only)

## Risks & Mitigations
- Local environments might diverge from Supabase defaults → Guard only creates the role if missing, keeping hosted environments unaffected.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126a8e44648323a0f3a0aadc06c8e6)