### PR TITLE
Fix Supabase lint workflow TLS failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:6543/postgres
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:6543/postgres?sslmode=disable
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Ensure the Supabase CLI connects to the CI Postgres service without attempting TLS.
- Append `sslmode=disable` to the workflow `DATABASE_URL` used during Supabase schema checks.
- Prevent future `supabase db lint` failures caused by TLS negotiation against the local container.

## Plan
1. Reproduce the Supabase CI lint error output to confirm the TLS failure scenario.
2. Inspect the GitHub Actions workflow that provisions the local Postgres service.
3. Update the workflow `DATABASE_URL` to include `sslmode=disable` for local connections.
4. Verify other workflow steps (psql migrations and seeds) remain compatible with the new connection string.
5. Document the change in the PR summary and note that no additional tests were required.

## Changes
- .github/workflows/ci.yml

## Verification
Commands:
```
# Not run (workflow change only)
```
Evidence:
- n/a

## Risks & Mitigations
- Workflow-only change → Monitor the next CI run to ensure Supabase lint succeeds with the adjusted connection string.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126bb140fc83239c3b6f1bc2a10da6)