### PR TITLE
Fix Supabase lint step to disable SSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,6 @@ jobs:
           echo "Seeding database"
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/seed.sql
       - name: Supabase db lint
+        env:
+          PGSSLMODE: disable
         run: supabase db lint --db-url "$DATABASE_URL" --fail-on error


### PR DESCRIPTION
## Summary
- prevent the Supabase CLI from forcing a TLS connection against the local Postgres service
- export `PGSSLMODE=disable` for the lint step so migrations linting can run in CI

## Plan
1. Inspect the Supabase verification job configuration.
2. Update the lint step to disable SSL via environment variable.
3. Commit the change and rely on CI for validation.

## Changes
- .github/workflows/ci.yml

## Verification
Commands:
```
N/A
```
Evidence:
- Not run locally (workflow-only change)

## Risks & Mitigations
- Supabase CLI could still enforce TLS despite the env var → mitigation: rely on `PGSSLMODE=disable`, which `lib/pq` honors when parsing connections.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126e5d9da08323a762ac8e1e02f404)