### PR TITLE
Fix horizontal overflow across grid sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -312,6 +312,20 @@ h1 {
   margin: 0 auto;
 }
 
+/* Prevent grid/flex children from forcing horizontal overflow */
+.app-shell > *,
+.app-hero > *,
+.filters-panel > *,
+.trending-section > *,
+.trending-carousel,
+.trending-carousel > *,
+.genre-carousel,
+.genre-carousel > *,
+#dashboard > *,
+.browse-toolbar > * {
+  min-width: 0;
+}
+
 .app-hero {
   display: grid;
   gap: clamp(1rem, 2.5vw, 2.4rem);


### PR DESCRIPTION
## Summary
- add a shared `min-width: 0` rule for key grid and flex wrappers so their children can shrink within the viewport
- eliminate the horizontal scrollbar that appeared after the games finished loading on desktop and mobile widths

## Plan
1. Reproduce the overflow once data renders to understand which containers are stretching.
2. Identify the grid and flex wrappers whose children were sizing to max-content.
3. Add a scoped CSS rule to set `min-width: 0` on those wrapper children.
4. Reload the static site locally to confirm the layout reflows without horizontal scrolling.
5. Capture an updated screenshot to document the fixed layout.

## Changes
- style.css

## Verification
Commands:
```
npx http-server -p 4173
```
Evidence:
- Verified via Playwright that `document.documentElement.scrollWidth - clientWidth` is `0` after the change.
- ![Updated layout without horizontal scroll](browser:/invocations/wpwvevkt/artifacts/artifacts/after.png)

## Risks & Mitigations
- Other grid/flex containers may still surface edge overflow cases → the new selector covers all current top-level wrappers and can be extended if new sections are added.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912733c2d808323915c4339d4289c15)