### PR TITLE
fix: guard storage bucket provisioning when schema absent

### DIFF
--- a/supabase/migrations/20251111150000_media_workflow.sql
+++ b/supabase/migrations/20251111150000_media_workflow.sql
@@ -3,14 +3,21 @@
 
 begin;
 
--- Ensure storage buckets exist for public covers, authenticated media, archive, and pending uploads.
-insert into storage.buckets (id, name, public)
-values
-  ('game-covers', 'game-covers', true),
-  ('media-auth', 'media-auth', false),
-  ('media-archive', 'media-archive', false),
-  ('media-pending', 'media-pending', false)
-on conflict (id) do update set name = excluded.name, public = excluded.public;
+do $$
+begin
+  if to_regclass('storage.buckets') is not null then
+    insert into storage.buckets (id, name, public)
+    values
+      ('game-covers', 'game-covers', true),
+      ('media-auth', 'media-auth', false),
+      ('media-archive', 'media-archive', false),
+      ('media-pending', 'media-pending', false)
+    on conflict (id) do update set name = excluded.name, public = excluded.public;
+  else
+    raise notice 'storage schema not installed; skipping bucket provisioning';
+  end if;
+end;
+$$;
 
 -- Create role for content moderators if it does not exist.
 do $$


### PR DESCRIPTION
## Summary
- guard bucket provisioning insert to avoid failures when the storage schema is unavailable
- surface a notice so deploy logs still reflect skipped storage setup

## Plan
1. Inspect the failing migration touching `storage.buckets`.
2. Confirm whether the storage schema can be missing in some environments.
3. Wrap the bucket provisioning logic in a conditional DO block.
4. Emit a notice when provisioning is skipped to aid debugging.
5. Review the migration file for syntax correctness.

## Changes
- supabase/migrations/20251111150000_media_workflow.sql

## Verification
Commands:
```
# not run (SQL-only change)
```
Evidence:
- n/a (SQL-only migration guard)

## Risks & Mitigations
- Migration may silently skip bucket creation if storage is intentionally disabled → Notice message clarifies the behavior for operators.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917375761f88323805f8323a2cc83d8)