### PR TITLE
fix: configure lighthouse server cache ttl

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "seed:generate": "node scripts/generate-seed-sql.js",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
-    "serve:lighthouse": "http-server . -p 4173 -a 127.0.0.1 -c-1 --silent",
+    "serve:lighthouse": "http-server . -p 4173 -a 127.0.0.1 -c 604800 --silent",
     "lighthouse": "npx @lhci/cli autorun --config=lighthouserc.json",
     "sitemap": "node scripts/generate-sitemap.js",
     "prices:update": "node scripts/update-price-snapshots.js",


### PR DESCRIPTION
## Summary
Set the Lighthouse static server to advertise a positive cache lifetime so the `uses-long-cache-ttl` audit can pass while retaining the existing workflow entry point.

## Plan
1. Review the existing `serve:lighthouse` script and locate the cache setting flag.
2. Update the http-server invocation to use a positive max-age value.
3. Verify the change by running the Lighthouse CI command locally.
4. Inspect the command output for cache TTL assertion results or errors.
5. Document any verification limitations encountered.

## Changes
- Updated `package.json` to configure `http-server` with a one-week cache TTL for Lighthouse runs.

## Verification
Commands:
```
npm run lighthouse
```
Evidence:
- Failed: `npm run lighthouse` (403 fetching `@lhci/cli` from registry; environment-restricted)

## Risks & Mitigations
- Risk: Longer cache TTL might mask asset freshness issues during manual testing → Mitigation: change only applies to the Lighthouse-specific server script.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178fe2f4f88323ad2010007f827c45)