### PR TITLE
Remove hero dashboard tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,10 +92,7 @@
         <!-- Hero Dashboard - Stats First -->
         <section class="hero-dashboard" aria-label="Collection dashboard">
           <h2 class="dashboard-title">Your Hoard Ledger at a Glance</h2>
-          <p class="dashboard-subtitle">
-            Guard your prized finds and seek new gems to grow the hoard—every discovery
-            counts.
-          </p>
+          <p class="dashboard-subtitle"></p>
           <div class="dashboard-grid" id="dashboardGrid">
             <!-- Owned Games Card -->
             <div class="stat-card">


### PR DESCRIPTION
## Summary
Removed the hero dashboard tagline text per request to eliminate the existing message from the subtitle area.

## Plan
1. Locate the hero dashboard subtitle copy in `index.html`.
2. Remove the tagline text while preserving layout structure.
3. Verify no additional references remain.

## Changes
- Cleared the dashboard subtitle content in the hero section of `index.html`.

## Verification
Commands:
```
None (not run; copy-only change)
```
Evidence:
- Not run (copy-only change)

## Risks & Mitigations
- Potential minor layout shift from empty subtitle element → Layout impact expected to be minimal; element retained to preserve spacing.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935ef13fc8883238991f25ab2caae4e)

## Summary by Sourcery

Enhancements:
- Leave an empty hero dashboard subtitle element in place to maintain spacing and visual layout.