### PR TITLE
Remove remote font dependency for Lighthouse stability

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,15 +31,7 @@
     <meta name="twitter:image" content="/favicon.png" />
 
     <!-- Preconnect to external resources -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-
-    <!-- Google Fonts - Load in HTML for faster rendering -->
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap"
-    />
 
     <!-- New Design System Styles -->
     <link rel="stylesheet" href="style.css" />

--- a/style.css
+++ b/style.css
@@ -21,8 +21,6 @@
 /* Import Utilities */
 @import url("style/utilities.css");
 
-/* Note: Google Fonts are now loaded in index.html for faster rendering */
-
 /* App Shell */
 .app-shell {
   min-height: 100vh;

--- a/style/tokens.css
+++ b/style/tokens.css
@@ -36,9 +36,10 @@
   --spacing-xxl: 64px;
 
   /* Typography */
-  --font-display: "Rajdhani", "Inter", system-ui;
-  --font-body: "Inter", system-ui;
-  --font-accent: "Space Mono", monospace;
+  /* System-first font stacks to avoid remote font requests during CI */
+  --font-display: "Inter", "Segoe UI", "Helvetica Neue", Arial, system-ui, sans-serif;
+  --font-body: "Inter", "Segoe UI", "Helvetica Neue", Arial, system-ui, sans-serif;
+  --font-accent: "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
 
   --font-size-xs: 12px;
   --font-size-sm: 14px;


### PR DESCRIPTION
## Summary
- Remove Google Fonts stylesheet/preconnects to avoid third-party latency in Lighthouse runs.
- Switch typography tokens to system-first stacks so styles remain consistent without remote assets.
- Clean up CSS comments now that fonts are fully local/system provided.

## Plan
1. Drop external font preconnects and stylesheet from `index.html`.
2. Update `style/tokens.css` font variables to use system-first stacks.
3. Clean up CSS comments related to remote font loading.
4. Recheck Lighthouse in CI after changes.

## Changes
- `index.html`: remove Google Fonts links and unused preconnects.
- `style/tokens.css`: update font token stacks to system defaults.
- `style.css`: remove outdated font-loading note.

## Verification
Commands:
```
# Not run in this environment
```
Evidence:
- N/A

## Risks & Mitigations
- Slight visual differences due to font stack change → use neutral system-first stacks to minimize impact.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936cc848bf8832385c93003d1126d9f)

## Summary by Sourcery

Remove external Google Fonts dependencies and rely on system-first font stacks to improve Lighthouse stability and avoid remote font requests.

Enhancements:
- Switch typography tokens to system-first font stacks for display, body, and accent text.
- Clean up outdated comments related to Google Fonts loading in CSS.
- Retain only necessary preconnects in the HTML head by removing Google Fonts preconnect and stylesheet links.