### PR TITLE
Refine eBay refresh handling and share ingestion helpers

### DIFF
--- a/scripts/shared/ingestion.cjs
+++ b/scripts/shared/ingestion.cjs
@@ -1,0 +1,105 @@
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("csv-parse/sync");
+const dotenv = require("dotenv");
+
+function loadEnv(rootPath) {
+  const envFile = path.join(rootPath, ".env");
+  if (fs.existsSync(envFile)) {
+    dotenv.config({ path: envFile });
+  }
+}
+
+function ensureFileExists(filePath, friendlyName) {
+  if (!fs.existsSync(filePath)) {
+    console.error(`❌ Missing ${friendlyName}: ${filePath}`);
+    process.exit(1);
+  }
+}
+
+function buildGameKey(name, platform) {
+  if (!name || !platform) return null;
+  return `${name}___${platform}`;
+}
+
+function resolveRegionCodes(raw) {
+  if (!raw) return [];
+  const normalized = raw.toString().toLowerCase();
+  const codes = new Set();
+  if (/ntsc|usa|north america|canada/.test(normalized)) codes.add("NTSC");
+  if (/pal|europe|uk|australia/.test(normalized)) codes.add("PAL");
+  if (/jpn|japan/.test(normalized)) codes.add("JPN");
+  return Array.from(codes);
+}
+
+function readGames(csvPath, filter) {
+  ensureFileExists(csvPath, "games.csv");
+  const csvContent = fs.readFileSync(csvPath, "utf8");
+  const records = parse(csvContent, { columns: true, skip_empty_lines: true });
+  const unique = new Map();
+  records.forEach((row) => {
+    const name = row["Game Name"]?.trim();
+    const platform = row["Platform"]?.trim();
+    const key = buildGameKey(name, platform);
+    if (!key || unique.has(key)) return;
+    if (filter && !key.toLowerCase().includes(filter)) return;
+    unique.set(key, {
+      key,
+      name,
+      platform,
+      regionRaw: row["Region"]?.trim() || "",
+      regionCodes: resolveRegionCodes(row["Region"]?.trim()),
+    });
+  });
+  return Array.from(unique.values());
+}
+
+function readCache(cachePath, logger = console) {
+  if (!fs.existsSync(cachePath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(cachePath, "utf8"));
+  } catch (error) {
+    logger.warn(
+      `Failed to parse cache file at ${cachePath}; ignoring cache and continuing.`,
+      error
+    );
+    return {};
+  }
+}
+
+function writeCache(cachePath, content) {
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+  fs.writeFileSync(cachePath, JSON.stringify(content, null, 2));
+}
+
+function hoursSince(timestamp) {
+  if (!timestamp) return Infinity;
+  const diff = Date.now() - new Date(timestamp).getTime();
+  return diff / (1000 * 60 * 60);
+}
+
+async function ensureFetch() {
+  if (typeof fetch === "function") return fetch;
+  const { default: fetchImpl } = await import("node-fetch");
+  global.fetch = fetchImpl;
+  return fetchImpl;
+}
+
+function normalizeRefreshHours(value, defaultValue) {
+  const parsed = Number.parseInt(value ?? defaultValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return defaultValue;
+  return parsed;
+}
+
+module.exports = {
+  loadEnv,
+  ensureFileExists,
+  buildGameKey,
+  resolveRegionCodes,
+  readGames,
+  readCache,
+  writeCache,
+  hoursSince,
+  ensureFetch,
+  normalizeRefreshHours,
+};


### PR DESCRIPTION
## Summary
- Extract shared ingestion utilities for env loading, CSV parsing, caching, and fetch setup to reduce duplication across scripts.
- Adopt the shared helpers in the PriceCharting updater to keep ingestion logic consistent.
- Harden the eBay price updater with validated refresh intervals and clearer skip handling when no USD sold prices are available.

## Plan
1. Add a reusable ingestion helper module for common script behaviors.
2. Update existing ingestion scripts to consume the shared helpers.
3. Adjust the eBay updater to validate refresh intervals and treat missing USD data as a logged skip.

## Changes
- Added `scripts/shared/ingestion.cjs` with env, CSV, cache, fetch, and refresh utilities.
- Refactored `scripts/update-price-snapshots.js` to use the shared ingestion helpers.
- Updated `scripts/update-ebay-prices.js` to validate refresh hours, log cache parse issues, and skip when USD prices are absent.

## Verification
Commands:
```
npm test
```
Evidence:
- Vitest suite passing locally.

## Risks & Mitigations
- Currency handling still assumes USD for eBay data; skipping non-USD results avoids crashes but may require future conversion support.

## Follow-ups
- Consider currency conversion or site-specific handling for non-USD eBay global IDs if needed.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69387ceb8d388323bef065619548ba62)

## Summary by Sourcery

Extract shared ingestion utilities and apply them to price update scripts while tightening eBay refresh behavior and skip handling.

Enhancements:
- Introduce a shared ingestion helper module for env loading, CSV parsing, caching, fetch setup, and refresh interval normalization.
- Refactor the eBay and PriceCharting price updater scripts to consume the shared ingestion utilities and reduce duplicated logic.
- Improve eBay price refresh robustness by validating refresh intervals, logging cache parse errors, and distinguishing skipped items when no USD prices are found.