### PR TITLE
Ensure Supabase config ready before loading games

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -7,5 +7,6 @@ export {
   getClient as getSupabaseClient,
   isAvailable as isSupabaseAvailable,
   fetchGames as fetchSupabaseGames,
+  waitForSupabaseReady,
   resetClient as resetSupabaseClient,
 } from "./supabase";


### PR DESCRIPTION
## Summary
- add a readiness wait so the client only queries Supabase after the CDN and config.js have finished loading
- keep the existing sample fallback but log when Supabase config is missing past the timeout
- export the readiness helper for reuse across the data layer

## Plan
1. Detect when Supabase globals are available before fetching games.
2. Fall back cleanly to sample data if the client or config never arrive.
3. Verify the data layer and supporting scripts still pass automated tests.

## Changes
- src/data/supabase.ts
- src/data/loader.ts
- src/data/index.ts

## Verification
Commands:
```
npm test
```
Evidence:
- vitest suite pass

## Risks & Mitigations
- Supabase still might not load if config.js is absent → inject the script dynamically and fall back to samples after a timeout

## Follow-ups
- Consider loading config.js earlier in the document if we continue to see delayed globals in production


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69387c4a34948323806eb2495f4ae969)

## Summary by Sourcery

Ensure Supabase configuration is ready before attempting to load games and provide a clearer fallback to sample data when Supabase is unavailable.

New Features:
- Add a Supabase readiness helper that waits for CDN globals and config.js before use and expose it from the data index.

Bug Fixes:
- Prevent game loading from querying Supabase before its client and configuration have finished loading, reducing config.js race conditions.

Enhancements:
- Improve loader fallback behavior by logging when Supabase config is unavailable within the timeout and then using sample data instead.