### PR TITLE
Potential fix for code scanning alert no. 30: Shell command built from environment values

### DIFF
--- a/tests/build-css.test.js
+++ b/tests/build-css.test.js
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 
 const ROOT_DIR = path.resolve(__dirname, "..");
 const DIST_DIR = path.join(ROOT_DIR, "dist");
@@ -27,7 +27,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("creates dist directory if not exists", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
       expect(fs.existsSync(DIST_DIR)).toBe(true);
     });
 
@@ -82,7 +82,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("bundle includes component styles", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
       const minPath = path.join(DIST_DIR, "style.min.css");
       const content = fs.readFileSync(minPath, "utf8");
 
@@ -95,7 +95,7 @@ describe("scripts/build-css.js", () => {
     it("script exits with code 0 on success", () => {
       let exitCode = 0;
       try {
-        execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+        execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
       } catch {
         exitCode = 1;
       }
@@ -103,7 +103,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("generates production index.html with bundled CSS", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
       const indexPath = path.join(DIST_DIR, "index.html");
       expect(fs.existsSync(indexPath)).toBe(true);
 
@@ -113,7 +113,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("creates symlinks for required assets", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
 
       // Check symlinks or copies exist for key directories
       const dataPath = path.join(DIST_DIR, "data");


### PR DESCRIPTION
Potential fix for [https://github.com/sandgraal/retro-games/security/code-scanning/30](https://github.com/sandgraal/retro-games/security/code-scanning/30)

The problem is caused by constructing a shell command string using template literals with interpolated (dynamically-built) file paths, and passing it to `execSync()`, which invokes a shell. The better approach is to avoid the shell altogether. Instead, use `execFileSync()` from `node:child_process`, which takes the command and arguments as separate parameters, bypassing shell interpretation.

For each place in `tests/build-css.test.js` where `execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR })` is used, replace it with `execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR })`.

Additionally, since the test imports only `execSync` from `node:child_process`, update the import on line 7 to also import `execFileSync`.

Regions to change:
- Import statement on line 7: add `execFileSync`.
- Each usage like `execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR })` (lines 30, 85, 98, 106, 116): swap for `execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR })`.

No further method or variable definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Replace shell-based test command execution with direct process invocation for the CSS build script tests.

Bug Fixes:
- Address potential command injection by avoiding shell interpolation when invoking the build-css script in tests.

Enhancements:
- Import and use execFileSync in tests to run the Node script with separated arguments instead of a shell command.