### PR TITLE
Use process.execPath in build-css tests

### DIFF
--- a/tests/build-css.test.js
+++ b/tests/build-css.test.js
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
-import { execSync, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 const ROOT_DIR = path.resolve(__dirname, "..");
 const DIST_DIR = path.join(ROOT_DIR, "dist");
@@ -27,24 +27,24 @@ describe("scripts/build-css.js", () => {
     });
 
     it("creates dist directory if not exists", () => {
-      execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       expect(fs.existsSync(DIST_DIR)).toBe(true);
     });
 
     it("generates style.css debug bundle", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       const debugPath = path.join(DIST_DIR, "style.css");
       expect(fs.existsSync(debugPath)).toBe(true);
     });
 
     it("generates style.min.css minified bundle", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       const minPath = path.join(DIST_DIR, "style.min.css");
       expect(fs.existsSync(minPath)).toBe(true);
     });
 
     it("minified bundle is smaller than debug bundle", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       const debugPath = path.join(DIST_DIR, "style.css");
       const minPath = path.join(DIST_DIR, "style.min.css");
 
@@ -55,7 +55,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("debug bundle includes source file markers", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       const debugPath = path.join(DIST_DIR, "style.css");
       const content = fs.readFileSync(debugPath, "utf8");
 
@@ -64,7 +64,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("minified bundle has no @import statements", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       const minPath = path.join(DIST_DIR, "style.min.css");
       const content = fs.readFileSync(minPath, "utf8");
 
@@ -72,7 +72,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("bundle includes CSS custom properties from tokens", () => {
-      execSync(`node ${SCRIPT_PATH}`, { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       const minPath = path.join(DIST_DIR, "style.min.css");
       const content = fs.readFileSync(minPath, "utf8");
 
@@ -82,7 +82,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("bundle includes component styles", () => {
-      execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       const minPath = path.join(DIST_DIR, "style.min.css");
       const content = fs.readFileSync(minPath, "utf8");
 
@@ -95,7 +95,7 @@ describe("scripts/build-css.js", () => {
     it("script exits with code 0 on success", () => {
       let exitCode = 0;
       try {
-        execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
+        execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       } catch {
         exitCode = 1;
       }
@@ -103,7 +103,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("generates production index.html with bundled CSS", () => {
-      execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
       const indexPath = path.join(DIST_DIR, "index.html");
       expect(fs.existsSync(indexPath)).toBe(true);
 
@@ -113,7 +113,7 @@ describe("scripts/build-css.js", () => {
     });
 
     it("creates symlinks for required assets", () => {
-      execFileSync("node", [SCRIPT_PATH], { cwd: ROOT_DIR });
+      execFileSync(process.execPath, [SCRIPT_PATH], { cwd: ROOT_DIR });
 
       // Check symlinks or copies exist for key directories
       const dataPath = path.join(DIST_DIR, "data");


### PR DESCRIPTION
## Summary
- remove the unused `execSync` import in the CSS build script tests
- run the build-css script through `process.execPath` to avoid PATH reliance
- verify the tests still cover bundle outputs

## Plan
1. Update test runner invocations to use the current Node binary via `process.execPath`.
2. Drop the now-unused `execSync` import.
3. Run the affected Vitest suite.

## Changes
- tests/build-css.test.js

## Verification
Commands:
```
npm test -- tests/build-css.test.js
```
Evidence:
- Vitest output showing all 11 build-css tests passing

## Risks & Mitigations
- Minimal risk; changes only affect test harness execution. Verified by rerunning the suite.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c12b98488323ad309e72faac7e2f)

## Summary by Sourcery

Update CSS build script tests to invoke the script using the current Node binary instead of relying on the PATH.

Tests:
- Adjust build-css test invocations to use process.execPath with execFileSync for running the script.
- Remove the unused execSync import from the build-css test file.