### PR TITLE
Fix formatting to satisfy format:check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A TypeScript + Vite single-page app for tracking retro games. It uses a lightwei
   - `POST /api/v1/games/new` to suggest new games.
 
   **Note:** Anonymous submissions are fully supported for both suggestion endpoints. All anonymous submissions are subject to moderation and require approval by a moderator or admin before being applied, just like submissions from authenticated contributors. There are no additional moderation steps or different approval workflows for anonymous users; all submissions, regardless of authentication status, enter the same moderation queue and are reviewed according to the same criteria.
+
 - Moderation queue: `GET /api/v1/moderation/suggestions` (moderator/admin only) with `POST .../decision` for approvals/rejections; decisions are recorded to `audit-log.json` and approved patches are applied during the next ingest run.
 
 ## Development

--- a/src/data/auth.ts
+++ b/src/data/auth.ts
@@ -17,7 +17,10 @@ function ensureSessionId(): string {
   let generated: string;
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     generated = crypto.randomUUID();
-  } else if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+  } else if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.getRandomValues === "function"
+  ) {
     // Manually generate a RFC4122 v4 UUID using crypto.getRandomValues
     // From: https://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid
     const bytes = new Uint8Array(16);
@@ -25,7 +28,7 @@ function ensureSessionId(): string {
     // Set version and variant bits as per RFC
     bytes[6] = (bytes[6] & 0x0f) | 0x40;
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    const hex = Array.from(bytes, b => b.toString(16).padStart(2, "0")).join("");
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
     generated =
       hex.substr(0, 8) +
       "-" +
@@ -37,7 +40,9 @@ function ensureSessionId(): string {
       "-" +
       hex.substr(20, 12);
   } else {
-    throw new Error("Cryptographically secure random number generation is required but not available.");
+    throw new Error(
+      "Cryptographically secure random number generation is required but not available."
+    );
   }
   window.localStorage.setItem(SESSION_STORAGE_KEY, generated);
   return generated;
@@ -53,15 +58,15 @@ function sanitizeRole(rawRole: unknown): AuthRole {
 async function loadSupabaseRole(): Promise<{ role: AuthRole; email: string | null }> {
   const ready = await waitForSupabaseReady();
   if (!ready) return { role: "anonymous", email: null };
-  const client = getClient() as unknown as
-    | {
-        auth?: { getSession?: () => Promise<{ data?: { session?: { user?: any } } }> };
-      }
-    | null;
+  const client = getClient() as unknown as {
+    auth?: { getSession?: () => Promise<{ data?: { session?: { user?: any } } }> };
+  } | null;
   const session = await client?.auth?.getSession?.();
   const user = session?.data?.session?.user;
   const roleFromMetadata =
-    user?.app_metadata?.role || user?.user_metadata?.role || (user ? "contributor" : "anonymous");
+    user?.app_metadata?.role ||
+    user?.user_metadata?.role ||
+    (user ? "contributor" : "anonymous");
   return {
     role: sanitizeRole(roleFromMetadata),
     email: (user?.email as string | undefined) ?? null,
@@ -75,7 +80,11 @@ export async function getAuthSession(): Promise<AuthSession> {
       ? sanitizeRole(window.localStorage.getItem(UNSAFE_ROLE_OVERRIDE_KEY))
       : "anonymous";
   const supabaseRole = await loadSupabaseRole();
-  return { sessionId, role: override !== "anonymous" ? override : supabaseRole.role, email: supabaseRole.email };
+  return {
+    sessionId,
+    role: override !== "anonymous" ? override : supabaseRole.role,
+    email: supabaseRole.email,
+  };
 }
 
 export function buildAuthHeaders(session: AuthSession): Record<string, string> {

--- a/src/data/suggestions.ts
+++ b/src/data/suggestions.ts
@@ -42,14 +42,10 @@ export async function decideSuggestion(
   decision: ModerationDecision,
   moderatorEmail: string
 ): Promise<{ suggestion: SuggestionRecord; audit?: AuditLogEntry }> {
-  const response = await send(
-    `/api/suggestions/${suggestionId}/decide`,
-    "POST",
-    {
-      ...decision,
-      moderator_email: moderatorEmail,
-    }
-  );
+  const response = await send(`/api/suggestions/${suggestionId}/decide`, "POST", {
+    ...decision,
+    moderator_email: moderatorEmail,
+  });
 
   // Return response as-is, audit may be undefined which is now correctly typed
   return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,8 +115,7 @@ async function init(): Promise<void> {
     checkUrlGuidesView();
 
     // Moderation UI (hidden for non-moderators by default)
-    const shouldShowModeration =
-      ["moderator", "admin"].includes(authSession.role);
+    const shouldShowModeration = ["moderator", "admin"].includes(authSession.role);
     if (shouldShowModeration) {
       cleanupFunctions.push(mountModerationPanel("#moderationPanel"));
       const moderationEl = document.getElementById("moderationPanel");

--- a/src/ui/moderation.ts
+++ b/src/ui/moderation.ts
@@ -1,17 +1,20 @@
 import type { SuggestionRecord } from "../core/types";
 import { getAuthSession } from "../data/auth";
-import {
-  decideSuggestion,
-  fetchSuggestionsForModeration,
-} from "../data/suggestions";
+import { decideSuggestion, fetchSuggestionsForModeration } from "../data/suggestions";
 import { el, mount } from "./components";
 
 function renderDiffRow(key: string, before: unknown, after: unknown): HTMLElement {
   return el.div(
     { class: "moderation-diff", role: "listitem" },
     el.span({ class: "moderation-diff__key" }, key),
-    el.span({ class: "moderation-diff__before" }, before === undefined ? "—" : String(before)),
-    el.span({ class: "moderation-diff__after" }, after === undefined ? "—" : String(after))
+    el.span(
+      { class: "moderation-diff__before" },
+      before === undefined ? "—" : String(before)
+    ),
+    el.span(
+      { class: "moderation-diff__after" },
+      after === undefined ? "—" : String(after)
+    )
   );
 }
 
@@ -27,7 +30,8 @@ function renderSuggestionCard(
     el.span({}, `Submitted ${new Date(suggestion.submittedAt).toLocaleString()}`)
   );
 
-  const title = suggestion.delta.title || suggestion.delta.game_name || suggestion.targetId;
+  const title =
+    suggestion.delta.title || suggestion.delta.game_name || suggestion.targetId;
   const titleEl = document.createElement("h3");
   titleEl.className = "moderation-card__title";
   titleEl.textContent = String(title ?? "Suggestion");
@@ -38,7 +42,13 @@ function renderSuggestionCard(
   const canonical = suggestion.canonical || {};
   const keys = Object.keys(suggestion.delta || {});
   keys.forEach((key) => {
-    diffList.append(renderDiffRow(key, (canonical as Record<string, unknown>)[key], suggestion.delta[key]));
+    diffList.append(
+      renderDiffRow(
+        key,
+        (canonical as Record<string, unknown>)[key],
+        suggestion.delta[key]
+      )
+    );
   });
   if (!keys.length) {
     diffList.append(el.div({ class: "moderation-empty" }, "No fields provided"));
@@ -46,7 +56,9 @@ function renderSuggestionCard(
   card.append(diffList);
 
   if (suggestion.notes) {
-    card.append(el.div({ class: "moderation-note" }, `Submitter note: ${suggestion.notes}`));
+    card.append(
+      el.div({ class: "moderation-note" }, `Submitter note: ${suggestion.notes}`)
+    );
   }
 
   const actionBar = el.div({ class: "moderation-actions" });
@@ -58,8 +70,15 @@ function renderSuggestionCard(
   });
   const approveBtn = el.button({ class: "btn btn-primary" }, "Approve & merge");
   const rejectBtn = el.button({ class: "btn" }, "Reject");
-  const errorEl = el.div({ class: "moderation-error", role: "alert", style: "display: none;" });
-  const retryBtn = el.button({ class: "btn btn-retry", style: "display: none;" }, "Retry");
+  const errorEl = el.div({
+    class: "moderation-error",
+    role: "alert",
+    style: "display: none;",
+  });
+  const retryBtn = el.button(
+    { class: "btn btn-retry", style: "display: none;" },
+    "Retry"
+  );
 
   let isProcessing = false;
   let currentRetryHandler: (() => void) | null = null;
@@ -84,12 +103,12 @@ function renderSuggestionCard(
     errorEl.textContent = message;
     errorEl.style.display = "block";
     retryBtn.style.display = "inline-block";
-    
+
     // Remove old handler if it exists
     if (currentRetryHandler) {
       retryBtn.removeEventListener("click", currentRetryHandler);
     }
-    
+
     // Store and add new handler
     currentRetryHandler = retryAction;
     retryBtn.addEventListener("click", currentRetryHandler);
@@ -97,7 +116,7 @@ function renderSuggestionCard(
 
   const handleDecision = async (status: "approved" | "rejected") => {
     if (isProcessing) return;
-    
+
     setLoading(true);
     try {
       await onDecision(status, notesInput.value);
@@ -105,9 +124,10 @@ function renderSuggestionCard(
       // when loadSuggestions() is called after successful decision
     } catch (error) {
       setLoading(false);
-      const message = error instanceof Error 
-        ? error.message 
-        : "Unable to submit decision. Please try again.";
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to submit decision. Please try again.";
       showError(message, () => handleDecision(status));
     }
   };
@@ -178,7 +198,8 @@ export function mountModerationPanel(selector: string): () => void {
         });
         statusEl.textContent = "";
       } catch (error) {
-        statusEl.textContent = error instanceof Error ? error.message : "Failed to load suggestions";
+        statusEl.textContent =
+          error instanceof Error ? error.message : "Failed to load suggestions";
       }
     }
 

--- a/tests/catalog-ingest.test.ts
+++ b/tests/catalog-ingest.test.ts
@@ -1088,7 +1088,11 @@ describe("startReadApiServer", () => {
               targetId: gameKey,
               delta: { genres: ["RPG", "Updated"] },
               status: "pending",
-              author: { role: "contributor", email: "user@example.com", sessionId: "sess_123" },
+              author: {
+                role: "contributor",
+                email: "user@example.com",
+                sessionId: "sess_123",
+              },
               submittedAt: "2024-01-01T00:00:00.000Z",
               notes: "Updating genres",
             },
@@ -1129,7 +1133,11 @@ describe("startReadApiServer", () => {
               genres: ["Adventure"],
             },
             status: "pending",
-            author: { role: "contributor", email: "user@example.com", sessionId: "sess_789" },
+            author: {
+              role: "contributor",
+              email: "user@example.com",
+              sessionId: "sess_789",
+            },
             submittedAt: "2024-01-03T00:00:00.000Z",
             notes: "Submitting new game",
           },
@@ -1163,7 +1171,11 @@ describe("startReadApiServer", () => {
             targetId: null,
             delta: { title: "Pending Game", platform: "PS5" },
             status: "pending",
-            author: { role: "contributor", email: "user1@example.com", sessionId: "sess_1" },
+            author: {
+              role: "contributor",
+              email: "user1@example.com",
+              sessionId: "sess_1",
+            },
             submittedAt: "2024-01-01T00:00:00.000Z",
           },
           {
@@ -1172,7 +1184,11 @@ describe("startReadApiServer", () => {
             targetId: null,
             delta: { title: "Approved Game", platform: "Xbox" },
             status: "approved",
-            author: { role: "contributor", email: "user2@example.com", sessionId: "sess_2" },
+            author: {
+              role: "contributor",
+              email: "user2@example.com",
+              sessionId: "sess_2",
+            },
             submittedAt: "2024-01-02T00:00:00.000Z",
           },
           {
@@ -1181,7 +1197,11 @@ describe("startReadApiServer", () => {
             targetId: null,
             delta: { title: "Rejected Game", platform: "PC" },
             status: "rejected",
-            author: { role: "contributor", email: "user3@example.com", sessionId: "sess_3" },
+            author: {
+              role: "contributor",
+              email: "user3@example.com",
+              sessionId: "sess_3",
+            },
             submittedAt: "2024-01-03T00:00:00.000Z",
           },
         ],
@@ -1233,7 +1253,7 @@ describe("startReadApiServer", () => {
 describe("applyApprovedSuggestions", () => {
   test("applies approved update suggestion to existing record", () => {
     const records = {
-      "sonic___genesis": {
+      sonic___genesis: {
         record: {
           title: "Sonic",
           platform: "Genesis",
@@ -1300,7 +1320,7 @@ describe("applyApprovedSuggestions", () => {
 
   test("increments version for updated records", () => {
     const records = {
-      "mario___nes": {
+      mario___nes: {
         record: {
           title: "Mario",
           platform: "NES",
@@ -1345,7 +1365,7 @@ describe("applyApprovedSuggestions", () => {
     };
 
     const records = {
-      "zelda___nes": {
+      zelda___nes: {
         record: originalRecord,
         hash: computeRecordHash(originalRecord),
         version: 1,
@@ -1377,7 +1397,7 @@ describe("applyApprovedSuggestions", () => {
 
   test("skips pending suggestions", () => {
     const records = {
-      "metroid___nes": {
+      metroid___nes: {
         record: {
           title: "Metroid",
           platform: "NES",
@@ -1411,7 +1431,7 @@ describe("applyApprovedSuggestions", () => {
 
   test("skips rejected suggestions", () => {
     const records = {
-      "castlevania___nes": {
+      castlevania___nes: {
         record: {
           title: "Castlevania",
           platform: "NES",
@@ -1445,13 +1465,13 @@ describe("applyApprovedSuggestions", () => {
 
   test("properly counts applied suggestions", () => {
     const records = {
-      "game1___platform1": {
+      game1___platform1: {
         record: { title: "Game1", platform: "Platform1", source: ["src1"] },
         hash: "hash4",
         version: 1,
         lastSeen: "2024-01-01T00:00:00.000Z",
       },
-      "game2___platform2": {
+      game2___platform2: {
         record: { title: "Game2", platform: "Platform2", source: ["src2"] },
         hash: "hash5",
         version: 1,
@@ -1499,7 +1519,7 @@ describe("applyApprovedSuggestions", () => {
 
   test("handles suggestions with missing delta/payload", () => {
     const records = {
-      "game___platform": {
+      game___platform: {
         record: { title: "Game", platform: "Platform", source: ["src"] },
         hash: "hash6",
         version: 1,
@@ -1526,7 +1546,7 @@ describe("applyApprovedSuggestions", () => {
 
   test("handles update suggestions with non-existent targetId", () => {
     const records = {
-      "existing___game": {
+      existing___game: {
         record: { title: "Existing", platform: "Game", source: ["src"] },
         hash: "hash7",
         version: 1,
@@ -1555,7 +1575,7 @@ describe("applyApprovedSuggestions", () => {
 
   test("handles new suggestions with existing keys", () => {
     const records = {
-      "duplicate___game": {
+      duplicate___game: {
         record: { title: "Duplicate", platform: "Game", source: ["original"] },
         hash: "hash8",
         version: 1,
@@ -1632,7 +1652,7 @@ describe("applyApprovedSuggestions", () => {
     };
 
     const records = {
-      "unchanged___platform": {
+      unchanged___platform: {
         record: originalRecord,
         hash: computeRecordHash(originalRecord),
         version: 2,
@@ -1666,7 +1686,7 @@ describe("applyApprovedSuggestions", () => {
 
   test("uses delta field for updates", () => {
     const records = {
-      "game___platform": {
+      game___platform: {
         record: { title: "Game", platform: "Platform", source: ["src"] },
         hash: "hash9",
         version: 1,
@@ -1692,7 +1712,7 @@ describe("applyApprovedSuggestions", () => {
 
   test("uses payload field for updates when delta is missing", () => {
     const records = {
-      "game2___platform": {
+      game2___platform: {
         record: { title: "Game2", platform: "Platform", source: ["src"] },
         hash: "hash10",
         version: 1,

--- a/tests/suggestions.test.ts
+++ b/tests/suggestions.test.ts
@@ -143,9 +143,7 @@ describe("Community Suggestions", () => {
       const result = await fetchPendingSuggestions();
 
       expect(result).toEqual(mockSuggestions);
-      expect(global.fetch).toHaveBeenCalledWith(
-        "/api/suggestions?status=pending"
-      );
+      expect(global.fetch).toHaveBeenCalledWith("/api/suggestions?status=pending");
     });
 
     it("should throw error on failed fetch", async () => {
@@ -201,11 +199,7 @@ describe("Community Suggestions", () => {
         json: async () => mockSuggestion,
       });
 
-      const result = await submitSuggestion(
-        "Earthbound",
-        "SNES",
-        "user@example.com"
-      );
+      const result = await submitSuggestion("Earthbound", "SNES", "user@example.com");
 
       expect(result.submitter_email).toBe("user@example.com");
     });


### PR DESCRIPTION
## Summary
- Ran Prettier to resolve existing formatting deviations in documentation, data helpers, moderation UI, and suggestion tests.
- Confirmed the repository now passes `npm run format:check`.

## Plan
1. Apply Prettier formatting to files flagged by the formatter.
2. Re-run `npm run format:check` to ensure clean output.

## Changes
- README moderation notes and related documentation lines.
- Auth/session helper and suggestion API helper formatting.
- Moderation panel UI logic formatting updates.
- Catalog ingest and suggestion test fixtures formatting.

## Verification
Commands:
```
npm run format:check
```
Evidence:
- Formatter reports all files compliant.

## Risks & Mitigations
- Formatting-only change; minimal risk.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a3e4db18083238e146fd29acecd34)

## Summary by Sourcery

Apply Prettier-driven formatting updates across moderation UI, auth and suggestion helpers, catalog ingest tests, and documentation to satisfy repository formatting checks.

Enhancements:
- Reformat moderation UI logic and suggestion data helpers to conform to project formatting standards.

Documentation:
- Tidy moderation-related README text formatting for consistency.

Tests:
- Reformat catalog ingest and suggestion tests for consistent style and linting compliance.

Chores:
- Standardize quote usage, line wrapping, and object key styles to ensure `format:check` passes cleanly.