### PR TITLE
Potential fix for code scanning alert no. 32: Exception text reinterpreted as HTML

### DIFF
--- a/services/catalog-ingest/catalog-ingest.js
+++ b/services/catalog-ingest/catalog-ingest.js
@@ -966,7 +966,7 @@ export function startReadApiServer({ port = 8787, preferredSnapshot } = {}) {
       res.end(
         JSON.stringify({
           error: "Failed to load catalog snapshot",
-          detail: error.message,
+          detail: "Internal server error",
         })
       );
     }


### PR DESCRIPTION
Potential fix for [https://github.com/sandgraal/retro-games/security/code-scanning/32](https://github.com/sandgraal/retro-games/security/code-scanning/32)

To prevent the exception message from leaking attacker-controlled content, we should sanitize or avoid reflecting the raw error message in the API response. The best approach is to replace any raw error details in responses with a generic message or to sanitize the content before including it.

**General approach:**  
- Avoid putting `error.message` directly into the API response. Instead, return a generic message (`"detail": "Internal server error"`) or sanitize the error message.

**Specific changes:**  
- In the catch block on line 964, change the response so that `detail` is a safe, generic message (e.g., `"Internal server error"`) or, if retaining some amount of error message, ensure it's properly escaped (though in API responses, just omitting it is standard).

**Methods and imports:**  
- No new imports required for simply using a generic message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent leaking attacker-controlled exception text in catalog snapshot load failures by returning a generic error detail instead of the raw error message.