### PR TITLE
Potential fix for code scanning alert no. 36: Incomplete string escaping or encoding

### DIFF
--- a/services/catalog-ingest/sources/igdb.js
+++ b/services/catalog-ingest/sources/igdb.js
@@ -470,7 +470,7 @@ export async function searchIgdbGames(query, options = {}) {
     const accessToken = await getAccessToken(clientId, clientSecret);
 
     const apicalypse = `
-      search "${query.replace(/"/g, '\\"')}";
+      search "${query.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}";
       fields ${GAME_FIELDS};
       where category = 0;
       limit ${limit};


### PR DESCRIPTION
Potential fix for [https://github.com/sandgraal/retro-games/security/code-scanning/36](https://github.com/sandgraal/retro-games/security/code-scanning/36)

To fully escape input for safe use in a quoted Apicalypse query string, all backslashes (`\`) must first be replaced by double-backslashes (`\\`), then all double-quote characters (`"`) replaced by escaped quotes (`\"`). This two-step process prevents an original backslash from becoming an escape for a quote. The fix should occur at the current usage location by replacing a single `.replace(/"/g, '\\"')` call with chained, global replaces: first for backslashes, then for quotes. No changes to functionality are needed—just a more complete string escaping.

- Only line 473 in `services/catalog-ingest/sources/igdb.js` needs updating.
- No new libraries are necessary for this fix, as JavaScript string replace with regex handles this safely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fully escape backslashes before quotes in IGDB search query strings to prevent malformed Apicalypse queries and address a code-scanning security alert.